### PR TITLE
Add FungiFi token to trusted token list

### DIFF
--- a/trusted-tokenlist.json
+++ b/trusted-tokenlist.json
@@ -127,6 +127,19 @@
       "decimals": 6,
       "logoURI": "https://arweave.net/oSDKVyoiP2eE4TNT_MrfJFGjFCkm1tCbkkEaFTJwBNE",
       "tags": []
+    },
+    {
+      "chainId": 101,
+      "name": "FungiFi",
+      "symbol": "FUNGI",
+      "address": "8BmWvBwJngQNHrvhaJE8QDameBz2YnVtDMXBGaCjCHsh",
+      "decimals": 9,
+      "logoURI": "https://fungifi.s3.us-east-2.amazonaws.com/Fungi.png",
+      "tags": ["meme-token"],
+      "extensions": {
+        "coingeckoId": "fungifi"
+      }
     }
+   
   ]
 }


### PR DESCRIPTION
This PR adds the FungiFi token to the trusted Solana token list.

- **Token Name**: FungiFi
- **Symbol**: FUNGI
- **Mint Address**: 8BmWvBwJngQNHrvhaJE8QDameBz2YnVtDMXBGaCjCHsh
- **Decimals**: 9
- **Logo URI**: https://fungifi.s3.us-east-2.amazonaws.com/Fungi.png
- **Tags**: ["meme-token"]
- **Extensions**: 
  - **Coingecko ID**: fungifi

Thank you for reviewing and merging this contribution.
