### PR TITLE
Add Fela Forever (Fela) to trusted-tokenlist.json

### DIFF
--- a/trusted-tokenlist.json
+++ b/trusted-tokenlist.json
@@ -228,6 +228,7 @@
     "website": "https://felaforever.com/",
     "twitter": "https://x.com/FelaForever",
     "createdOn": "https://pump.fun"
-  } 
- ]
+  }
+    }
+  ]
 }

--- a/trusted-tokenlist.json
+++ b/trusted-tokenlist.json
@@ -215,6 +215,19 @@
       "verified": true,
       "logoURI": "https://stablebonds.s3.us-west-2.amazonaws.com/stablebond/spl-ustry.png",
       "tags": []
-    }
-  ]
+    },
+    {
+  "name": "Fela Forever",
+  "symbol": "Fela",
+  "mint": "5gK7du17XyHMuLHUfKFiLnaHQQJ1geg2LprYd6dBpu",
+  "decimals": 9,
+  "description": "A MEME COIN TRIBUTE TO THE LEGEND OF AFROBEATS FELA KUTI\nFela Kuti was more than a musician—he was a revolutionary, a visionary, and a fearless voice for the oppressed.",
+  "logoURI": "https://ipfs.io/ipfs/QmRrTtmkbyhVpgnqKw8PVsv2bpPb2vKSWfGqGWqCtyuQWx",
+  "showName": true,
+  "extensions": {
+    "website": "https://felaforever.com/",
+    "twitter": "https://x.com/FelaForever",
+    "createdOn": "https://pump.fun"
+  } 
+ ]
 }


### PR DESCRIPTION
This PR adds the Fela Forever token to the trusted token list.

name	"Fela Forever"
symbol	"Fela"
description	" A MEME COIN TRIBUTE TO THE LEGEND OF AFROBEATS FELA KUTI\r\nFela Kuti was more than a musician—he was a revolutionary, a visionary, and a fearless voice for the oppressed."
image	"https://ipfs.io/ipfs/QmRrTtmkbyhVpgnqKw8PVsv2bpPb2vKSWfGqGWqCtyuQWx"
showName	true
createdOn	"https://pump.fun"
twitter	"https://x.com/FelaForever"
website	"https://felaforever.com/"
